### PR TITLE
Add noscript notice

### DIFF
--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -59,6 +59,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <noscript>This page doesn't work properly without javascript enabled, please enable it</noscript>
     <script src="./src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Add a noscript notice to the page for users who have disabled javascript, as requested in [a Hacker News comment](https://news.ycombinator.com/item?id=18318875).
Given that this SPA is pulling its content from wiki pages, it'd be awesome if we could change the noscript tag to contain a link to these wiki pages, but I haven't been able to think of any way to enable this.